### PR TITLE
Modify to support CI system

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -79,12 +79,22 @@ if [ "$debug" == "true" ]; then
     set -x
 fi
 
+# Track whether we have a valid oc identity
+source $SCRIPT_DIR/util
+check_ocp
+
+# If the NAMESPACE env var is set and the namespace doesn't exist, try to create it
+if [ ! -z ${NAMESPACE:-} ] && [ "$OCP" -eq 0 ]; then
+    set +e
+    oc get namespace $NAMESPACE
+    if [ "$?" -ne 0 ]; then
+        oc create namespace $NAMESPACE
+    fi
+    set -e
+fi
+
 # Sourcing common will source test/lib/init.sh
 source $TEST_DIR/common
-source $SCRIPT_DIR/util
-
-# Track whether we have a valid oc login
-check_ocp
 
 os::util::environment::setup_time_vars
 

--- a/setup.sh
+++ b/setup.sh
@@ -242,10 +242,20 @@ check_ocp
 # We have to have a login for operators and projects
 if [ "$operators" == "true" -o "$projects" == "true" ]; then
     if [ "$OCP" -ne 0 ]; then
-        echo "No active openshift login, can't set up projects or operators, exiting."
-        echo "To clone test subdirectories without an openshift login, run with the just '-t' option."
+        echo "No active openshift identity, can't set up projects or operators, exiting."
+        echo "To clone test subdirectories, run with the just '-t' option."
         exit 0
     fi
+fi
+
+# If the NAMESPACE env var is set and the namespace doesn't exist, try to create it
+if [ ! -z ${NAMESPACE:-} ] && [ "$OCP" -eq 0 ]; then
+    set +e
+    oc get namespace $NAMESPACE
+    if [ "$?" -ne 0 ]; then
+        oc create namespace $NAMESPACE
+    fi
+    set -e
 fi
 
 while IFS= read -r line

--- a/util
+++ b/util
@@ -2,7 +2,7 @@
 
 function check_ocp() {
     set +e
-    oc status &> /dev/null
+    oc whoami &> /dev/null
     res="$?"
     set -e
     OCP="$res"


### PR DESCRIPTION
This change modifies the test for an openshift identity to use
"oc whoami" instead of "oc status". It also will attempt to
create the namespace $NAMESPACE if the env var is set and that
namespace does not already exist.